### PR TITLE
Added Container Names

### DIFF
--- a/config_resource.tpl
+++ b/config_resource.tpl
@@ -59,8 +59,8 @@ export LOCAL_KC_CONFIG_PATH=${OUPTUT_CONFIGURATION_DIR}/keycloak/configuration
 export LOCAL_CANDIG_CONFIG_PATH=${OUPTUT_CONFIGURATION_DIR}/candig_server
 
 # Docker-compose naming
-export CANDIG_GATEWAY_SERVICE_NAME=candig
-export CANDIG_AUTH_SERVICE_NAME=candig_auth
+export CONTAINER_NAME_CANDIG_GATEWAY=candig
+export CONTAINER_NAME_CANDIG_AUTH=candig_auth
 
 # Do not touch, this is the adress seen by tyk (in compose its the name)
 export LOCAL_CANDIG_SERVER="http://candig_server:80"

--- a/config_resource.tpl
+++ b/config_resource.tpl
@@ -60,7 +60,7 @@ export LOCAL_CANDIG_CONFIG_PATH=${OUPTUT_CONFIGURATION_DIR}/candig_server
 
 # Docker-compose naming
 export CANDIG_GATEWAY_SERVICE_NAME=candig
-export CANDIG_AUTH_CONTAINER_NAME=candig_auth
+export CANDIG_AUTH_SERVICE_NAME=candig_auth
 
 # Do not touch, this is the adress seen by tyk (in compose its the name)
 export LOCAL_CANDIG_SERVER="http://candig_server:80"

--- a/config_resource.tpl
+++ b/config_resource.tpl
@@ -58,6 +58,9 @@ export LOCAL_TYK_CONFIG_PATH=${OUPTUT_CONFIGURATION_DIR}/tyk/confs
 export LOCAL_KC_CONFIG_PATH=${OUPTUT_CONFIGURATION_DIR}/keycloak/configuration
 export LOCAL_CANDIG_CONFIG_PATH=${OUPTUT_CONFIGURATION_DIR}/candig_server
 
+# Docker-compose naming
+export CANDIG_GATEWAY_SERVICE_NAME=candig
+export CANDIG_AUTH_CONTAINER_NAME=candig_auth
 
 # Do not touch, this is the adress seen by tyk (in compose its the name)
 export LOCAL_CANDIG_SERVER="http://candig_server:80"

--- a/script/kc_setup.sh
+++ b/script/kc_setup.sh
@@ -56,8 +56,8 @@ valid_json () {
 
 add_user() {
 
-# CANDIG_AUTH_SERVICE_NAME is the name of the keycloak server inside the compose network
-CONT_ID=$(docker ps  | grep ${CANDIG_AUTH_SERVICE_NAME} | cut -d " " -f1)
+# CONTAINER_NAME_CANDIG_AUTH is the name of the keycloak server inside the compose network
+CONT_ID=$(docker ps  | grep ${CONTAINER_NAME_CANDIG_AUTH} | cut -d " " -f1)
 docker exec ${CONT_ID} keycloak/bin/add-user-keycloak.sh -u ${KC_TEST_USER} -p ${KC_TEST_USER_PW} -r ${KC_REALM}
 echo restarting Keycloak
 docker restart ${CONT_ID}

--- a/script/kc_setup.sh
+++ b/script/kc_setup.sh
@@ -56,7 +56,7 @@ valid_json () {
 
 add_user() {
 
-# candigauth is the name of the keycloak server inside the compose network
+# candig_auth is the name of the keycloak server inside the compose network
 CONT_ID=$(docker ps  | grep candig_auth | cut -d " " -f1)
 docker exec ${CONT_ID} keycloak/bin/add-user-keycloak.sh -u ${KC_TEST_USER} -p ${KC_TEST_USER_PW} -r ${KC_REALM}
 echo restarting Keycloak

--- a/script/kc_setup.sh
+++ b/script/kc_setup.sh
@@ -56,8 +56,8 @@ valid_json () {
 
 add_user() {
 
-# candig_auth is the name of the keycloak server inside the compose network
-CONT_ID=$(docker ps  | grep ${CANDIG_AUTH_CONTAINER_NAME} | cut -d " " -f1)
+# CANDIG_AUTH_SERVICE_NAME is the name of the keycloak server inside the compose network
+CONT_ID=$(docker ps  | grep ${CANDIG_AUTH_SERVICE_NAME} | cut -d " " -f1)
 docker exec ${CONT_ID} keycloak/bin/add-user-keycloak.sh -u ${KC_TEST_USER} -p ${KC_TEST_USER_PW} -r ${KC_REALM}
 echo restarting Keycloak
 docker restart ${CONT_ID}

--- a/script/kc_setup.sh
+++ b/script/kc_setup.sh
@@ -57,7 +57,7 @@ valid_json () {
 add_user() {
 
 # candigauth is the name of the keycloak server inside the compose network
-CONT_ID=$(docker ps  | grep candigauth | cut -d " " -f1)
+CONT_ID=$(docker ps  | grep candig_auth | cut -d " " -f1)
 docker exec ${CONT_ID} keycloak/bin/add-user-keycloak.sh -u ${KC_TEST_USER} -p ${KC_TEST_USER_PW} -r ${KC_REALM}
 echo restarting Keycloak
 docker restart ${CONT_ID}

--- a/script/kc_setup.sh
+++ b/script/kc_setup.sh
@@ -57,7 +57,7 @@ valid_json () {
 add_user() {
 
 # candig_auth is the name of the keycloak server inside the compose network
-CONT_ID=$(docker ps  | grep candig_auth | cut -d " " -f1)
+CONT_ID=$(docker ps  | grep ${CANDIG_AUTH_CONTAINER_NAME} | cut -d " " -f1)
 docker exec ${CONT_ID} keycloak/bin/add-user-keycloak.sh -u ${KC_TEST_USER} -p ${KC_TEST_USER_PW} -r ${KC_REALM}
 echo restarting Keycloak
 docker restart ${CONT_ID}

--- a/script/tyk_setup.sh
+++ b/script/tyk_setup.sh
@@ -20,7 +20,7 @@ fi
 sed -i -r 's/KC_SECRET": "[a-zA-Z0-9]*"/KC_SECRET": "'"$KC_SECRET"'"/g'   ${LOCAL_TYK_CONFIG_PATH}/api_auth.json
 
 
-CONT_ID=$(docker ps  | grep ${CANDIG_GATEWAY_SERVICE_NAME}_1 | cut -d " " -f1)
+CONT_ID=$(docker ps  | grep ${CONTAINER_NAME_CANDIG_GATEWAY}_1 | cut -d " " -f1)
 echo restarting Tyk 
 docker restart ${CONT_ID}
 

--- a/script/tyk_setup.sh
+++ b/script/tyk_setup.sh
@@ -20,7 +20,7 @@ fi
 sed -i -r 's/KC_SECRET": "[a-zA-Z0-9]*"/KC_SECRET": "'"$KC_SECRET"'"/g'   ${LOCAL_TYK_CONFIG_PATH}/api_auth.json
 
 
-CONT_ID=$(docker ps  | grep candig | cut -d " " -f1)
+CONT_ID=$(docker ps  | grep candig_gateway | cut -d " " -f1)
 echo restarting Tyk 
 docker restart ${CONT_ID}
 

--- a/script/tyk_setup.sh
+++ b/script/tyk_setup.sh
@@ -20,7 +20,7 @@ fi
 sed -i -r 's/KC_SECRET": "[a-zA-Z0-9]*"/KC_SECRET": "'"$KC_SECRET"'"/g'   ${LOCAL_TYK_CONFIG_PATH}/api_auth.json
 
 
-CONT_ID=$(docker ps  | grep candig_1 | cut -d " " -f1)
+CONT_ID=$(docker ps  | grep ${CANDIG_GATEWAY_SERVICE_NAME}_1 | cut -d " " -f1)
 echo restarting Tyk 
 docker restart ${CONT_ID}
 

--- a/script/tyk_setup.sh
+++ b/script/tyk_setup.sh
@@ -20,7 +20,7 @@ fi
 sed -i -r 's/KC_SECRET": "[a-zA-Z0-9]*"/KC_SECRET": "'"$KC_SECRET"'"/g'   ${LOCAL_TYK_CONFIG_PATH}/api_auth.json
 
 
-CONT_ID=$(docker ps  | grep candig_gateway | cut -d " " -f1)
+CONT_ID=$(docker ps  | grep candig_1 | cut -d " " -f1)
 echo restarting Tyk 
 docker restart ${CONT_ID}
 

--- a/template/docker-compose.yml.tpl
+++ b/template/docker-compose.yml.tpl
@@ -10,8 +10,8 @@ services:
     depends_on:
     - tyk-redis
     - tyk-mongo
-    - candig
-  candig:
+    - ${CANDIG_GATEWAY_SERVICE_NAME}
+  ${CANDIG_GATEWAY_SERVICE_NAME}:
     image: tykio/tyk-gateway:v2.9.3.1
     ports:
     - "${TYK_GATW_LOCAL_PORT}:8080"
@@ -44,7 +44,7 @@ services:
     - tyk
   candigauth:
     image: jboss/keycloak:4.7.0.Final
-    container_name: candig_auth
+    container_name: ${CANDIG_AUTH_CONTAINER_NAME}
     ports:
     - "${KC_LOCAL_PORT}:8081"
     env_file:

--- a/template/docker-compose.yml.tpl
+++ b/template/docker-compose.yml.tpl
@@ -13,7 +13,6 @@ services:
     - candig
   candig:
     image: tykio/tyk-gateway:v2.9.3.1
-    container_name: candig_gateway
     ports:
     - "${TYK_GATW_LOCAL_PORT}:8080"
     networks:
@@ -32,14 +31,12 @@ services:
     - tyk-redis
   tyk-redis:
     image: redis:4.0.14-alpine
-    container_name: candig_redis
     volumes:
     - redis-data:/data
     networks:
     - tyk
   tyk-mongo:
     image: mongo:3.2
-    container_name: candig_mongo
     command: ["mongod", "--smallfiles"]
     volumes:
     - mongo-data:/data/db

--- a/template/docker-compose.yml.tpl
+++ b/template/docker-compose.yml.tpl
@@ -1,7 +1,19 @@
 version: '3.3'
 services:
+  tyk-pump:
+    image: tykio/tyk-pump-docker-pub:v0.5.3
+    container_name: candig_pump
+    networks:
+    - tyk
+    volumes:
+    - ${LOCAL_TYK_CONFIG_PATH}/pump.conf:/opt/tyk-pump/pump.conf
+    depends_on:
+    - tyk-redis
+    - tyk-mongo
+    - candig
   candig:
     image: tykio/tyk-gateway:v2.9.3.1
+    container_name: candig_gateway
     ports:
     - "${TYK_GATW_LOCAL_PORT}:8080"
     networks:
@@ -18,24 +30,16 @@ services:
     - ${LOCAL_TYK_CONFIG_PATH}/policies.json:/opt/tyk-gateway/policies/policies.json
     depends_on:
     - tyk-redis
-  tyk-pump:
-    image: tykio/tyk-pump-docker-pub:v0.5.3
-    networks:
-    - tyk
-    volumes:
-    - ${LOCAL_TYK_CONFIG_PATH}/pump.conf:/opt/tyk-pump/pump.conf
-    depends_on:
-    - tyk-redis
-    - tyk-mongo
-    - candig
   tyk-redis:
     image: redis:4.0.14-alpine
+    container_name: candig_redis
     volumes:
     - redis-data:/data
     networks:
     - tyk
   tyk-mongo:
     image: mongo:3.2
+    container_name: candig_mongo
     command: ["mongod", "--smallfiles"]
     volumes:
     - mongo-data:/data/db
@@ -43,6 +47,7 @@ services:
     - tyk
   candigauth:
     image: jboss/keycloak:4.7.0.Final
+    container_name: candig_auth
     ports:
     - "${KC_LOCAL_PORT}:8081"
     env_file:
@@ -53,6 +58,7 @@ services:
     - ${LOCAL_KC_CONFIG_PATH}/standalone-ha.xml:/opt/jboss/keycloak/standalone/configuration/standalone-ha.xml
   candig_server:
     image: c3genomics/candig_server
+    container_name: candig_server
     entrypoint:
     - candig_server
     - --host

--- a/template/docker-compose.yml.tpl
+++ b/template/docker-compose.yml.tpl
@@ -10,8 +10,8 @@ services:
     depends_on:
     - tyk-redis
     - tyk-mongo
-    - ${CANDIG_GATEWAY_SERVICE_NAME}
-  ${CANDIG_GATEWAY_SERVICE_NAME}:
+    - ${CONTAINER_NAME_CANDIG_GATEWAY}
+  ${CONTAINER_NAME_CANDIG_GATEWAY}:
     image: tykio/tyk-gateway:v2.9.3.1
     ports:
     - "${TYK_GATW_LOCAL_PORT}:8080"
@@ -42,9 +42,9 @@ services:
     - mongo-data:/data/db
     networks:
     - tyk
-  ${CANDIG_AUTH_SERVICE_NAME}:
+  ${CONTAINER_NAME_CANDIG_AUTH}:
     image: jboss/keycloak:4.7.0.Final
-    container_name: ${CANDIG_AUTH_SERVICE_NAME}
+    container_name: ${CONTAINER_NAME_CANDIG_AUTH}
     ports:
     - "${KC_LOCAL_PORT}:8081"
     env_file:

--- a/template/docker-compose.yml.tpl
+++ b/template/docker-compose.yml.tpl
@@ -1,6 +1,6 @@
 version: '3.3'
 services:
-  tyk-pump:
+  candig_pump:
     image: tykio/tyk-pump-docker-pub:v0.5.3
     container_name: candig_pump
     networks:
@@ -42,9 +42,9 @@ services:
     - mongo-data:/data/db
     networks:
     - tyk
-  candigauth:
+  ${CANDIG_AUTH_SERVICE_NAME}:
     image: jboss/keycloak:4.7.0.Final
-    container_name: ${CANDIG_AUTH_CONTAINER_NAME}
+    container_name: ${CANDIG_AUTH_SERVICE_NAME}
     ports:
     - "${KC_LOCAL_PORT}:8081"
     env_file:


### PR DESCRIPTION
Added explicit container names and updated set up scripts accordingly since the container names are hardcoded in. (It is a miracle that I noticed this)

Strangely, after making a request to /, I still got 302 -> 302 -> 200. But when I looked closer at the candig_setup output I somehow managed to notice a new set up error caused by the hard coded container names. This leads me to believe that there may be more areas where the names are hard coded that need to be changed. 

Please test this @amanjeev, and let me know of any easy ways to search a git repo for a string if you know any.