### PR TITLE
Removes tyk dashboard related env variables

### DIFF
--- a/config_resource.tpl
+++ b/config_resource.tpl
@@ -20,15 +20,6 @@ export KC_TEST_USER_PW=a_password
 export KC_ADMIN_USER=a_default_to_change_admin_per
 export KC_PW=a_default_to_change_kfjaskdihfowiehsgdv
 
-
-
-#Tyk admin
-export CANDIG_TYK_USERNAME=a_default_to_change_test_bed@mail.com
-export CANDIG_TYK_PASSWORD=a_default_to_change_my.only.bonne.idee.pour.un.good.pasword
-export TYK_DASH_FROM_EMAIL="maybe_you@my_mail.com"
-export TYK_DASH_FROM_NAME="your name"
-
-
 # typically the ports will be 443 and 443 for https adresses
 export CANDIG_PUBLIC_URL=http://candig.you_site.org
 export CANDIG_PUBLIC_PORT=8080
@@ -91,6 +82,3 @@ export AUTH_API_SLUG="authentication"
 export CANDIG_API_NAME="Candig Api"
 export CANDIG_API_ID="21"
 export CANDIG_API_SLUG="candig"
-
-# do not change
-export TYK_DASHB_LOCAL_PORT=3000


### PR DESCRIPTION
Problem: 
Some unused environment variables were remaining because we 
had removed the tyk dashboard but had not cleaned up everything.