### PR TITLE
Clarify a few points in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,12 +229,14 @@ Specific `$WORKDIR/config` setup:
 
 Make sure the public address starts with `https` and that the public PORT 
 are `443`, the you will be behind a proxy, so `PROXY_ADDRESS_FORWARDING=true`
+and now `SESSION_COOKIE_SECURE=True` (note different capitalizations):
 ```
 export CANDIG_PUBLIC_URL=https://<public  TYK address>
 export CANDIG_PUBLIC_PORT=443
 export KC_PUBLIC_URL=https://<public KC address>
 export KC_PUBLIC_PORT=443
 export PROXY_ADDRESS_FORWARDING=true
+export SESSION_COOKIE_SECURE=True
 ```
 
 #### The Apache httpd config

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ It might happen in production that the keycloak and tyk server are not running o
 not been started with compose or container. You can still configure then with the  `candig_setup.sh` script: 
 ```
 ./candig_setup.sh \
--o  $WORKDIR/config/conig -k keycloakhost:8081 -t tykhost
+-o  $WORKDIR/config/config -k keycloakhost:8081 -t tykhost
 ```
 
 ## Adding new API behind Tyk authentication

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ See instructions to install Docker: https://runnable.com/docker/getting-started/
 For this setup to work without a lot of changes, please make sure should
 be available on the machine where the CanDIG containers are deployed.
 
-* `8081`
-* `8080`
+* `8081` - keycloak http
+* `8080` - tyk API gateway
 
 Any other ports as more APIs are added.
 

--- a/README.md
+++ b/README.md
@@ -134,12 +134,16 @@ docker-compose logs -f
 
 #### Development
 
-Now that the containers are running, we have to create the credentials in Keycloak
-and forward the relevant information to tyk.
+Now that the containers are running, we have to configure the containers by 
+creating the credentials in Keycloak and forward the relevant information to tyk.
+
+The script connects to the containers locally, so use local, not public, hostnames;
+and for ports, keycloak can be connected to locally without TLS (so port 8081 rather
+than 8443):
 
 ```
 ./candig_setup.sh \
--o  $WORKDIR/config -k localhost:8081 -t localhost
+-o  $WORKDIR/config/config -k localhost:8081 -t localhost
 ```
 
 #### Production
@@ -148,7 +152,7 @@ It might happen in production that the keycloak and tyk server are not running o
 not been started with compose or container. You can still configure then with the  `candig_setup.sh` script: 
 ```
 ./candig_setup.sh \
--o  $WORKDIR/config -k keycloachost:8081 -t tykhost
+-o  $WORKDIR/config/conig -k keycloakhost:8081 -t tykhost
 ```
 
 ## Adding new API behind Tyk authentication

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ See instructions to install Docker: https://runnable.com/docker/getting-started/
 For this setup to work without a lot of changes, please make sure should
 be available on the machine where the CanDIG containers are deployed.
 
-* `3000`
 * `8081`
 * `8080`
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ and needs to be improved, among other things.
 
 ### Steps to add new API
 
+If at some point you want to add a new authenticated API behind the tyk gateway, these are the steps to take:
+
 1. *Create an API file*: Look at the [tyk/confs] directory. You can use [api_candig.json.tpl]
 as an example and modify from step 2.
 2. Edit the newly created API JSON file with following

--- a/config_resource.tpl
+++ b/config_resource.tpl
@@ -91,6 +91,3 @@ export AUTH_API_SLUG="authentication"
 export CANDIG_API_NAME="Candig Api"
 export CANDIG_API_ID="21"
 export CANDIG_API_SLUG="candig"
-
-# do not change
-export TYK_DASHB_LOCAL_PORT=3000

--- a/httpd_tls_proxy.conf
+++ b/httpd_tls_proxy.conf
@@ -1,4 +1,4 @@
-<VirtualHost proxy_local_ip:443>
+<VirtualHost *:443>
    ServerName candigauth.public.adress
    RemoteIPHeader X-Forwarded-For 
    RequestHeader set X-Forwarded-Proto "https"
@@ -17,7 +17,7 @@
    SSLCertificateChainFile  /etc/letsencrypt/live/candigauth.public.adress/fullchain.pem
 </VirtualHost>
 
-<VirtualHost proxy_local_ip:443>
+<VirtualHost *:443>
    ServerName candig.public.adress
    RemoteIPHeader X-Forwarded-For
    RequestHeader set X-Forwarded-Proto "https"
@@ -36,3 +36,17 @@
    SSLCertificateChainFile  /etc/letsencrypt/live/candig.public.adress/fullchain.pem
 </VirtualHost>
 
+# If you want to redirect http to https:
+<VirtualHost *:80> 
+   ServerName  candigauth.public.adress
+   #RemoteIPHeader X-Forwarded-For
+   #ProxyPreserveHost On
+   Redirect permanent / https://<public Keycloak Address>
+</VirtualHost>
+
+<VirtualHost *:80> 
+   ServerName  candig.public.adress
+   #RemoteIPHeader X-Forwarded-For
+   #ProxyPreserveHost On
+   Redirect permanent / https://<public Tyk Address>
+</VirtualHost>


### PR DESCRIPTION
- Clarify that this adding APIs is an optional step for adding new functionality
- Improve apache setup description , include required modules
- Clarify to use local hostnames and ports for candig_setup
- Remove references to port 3000; not using dashboard anymore
- Clarify what ports are for